### PR TITLE
Rework servo driver for kernel 4.4

### DIFF
--- a/modules/servo/Makefile
+++ b/modules/servo/Makefile
@@ -1,5 +1,9 @@
+ifneq ($(KERNELRELEASE),)
 obj-m += servo.o
-all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
-clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+else
+KDIR ?= /lib/modules/`uname -r`/build
+
+default:
+	$(MAKE) -C $(KDIR) M=$$PWD
+
+endif

--- a/modules/servo/devicetree.txt
+++ b/modules/servo/devicetree.txt
@@ -1,0 +1,25 @@
+Example DT node for this driver (BeagleBone Black):
+
+/ {
+        ocp {
+                servo_P9_16 {
+                        compatible      = "pwm_servo";
+                        pwms            = <&ehrpwm1 1 20000000 1>;
+                        pwm-names       = "PWM_P9_16";
+                        pinctrl-names   = "default";
+                        pinctrl-0       = <&pwm_P9_16>;
+                        enabled         = <0>;
+                        duty            = <0>;
+                        status          = "okay";
+                };
+        };
+};
+
+To configure selected pin to PWM:
+
+&am33xx_pinmux {
+        pwm_P9_16: pinmux_pwm_P9_16_pins {
+                pinctrl-single,pins = <0x04c  0x6>; /* P9_16 (ZCZ ball T14) | MODE 6 */
+        };
+};
+


### PR DESCRIPTION
Major update to servo driver, featuring (beyond others):
- reading PWM pin from DT
- use of platform driver subsystem
- use of pinctrl to claim pins
- managed functions (devm_*) where applicable
- error checks on return values

and few other minor changes.
