### PR TITLE
Rework TB6612 driver

### DIFF
--- a/modules/tb6612/Makefile
+++ b/modules/tb6612/Makefile
@@ -1,5 +1,9 @@
+ifneq ($(KERNELRELEASE),)
 obj-m += tb6612.o
-all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
-clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+else
+KDIR ?= /lib/modules/`uname -r`/build
+
+default:
+	$(MAKE) -C $(KDIR) M=$$PWD
+
+endif


### PR DESCRIPTION
Multiple improvments
- use platform device model
- DT instead of hard-coded configuration
- simple motor/chip abstraction
- use new PWM/GPIO/Pinctrl kernel API
- other minor changes
